### PR TITLE
Add 2 more tests and fix 1 incorrect conclusion

### DIFF
--- a/documentation/GetPrivateProfileString.md
+++ b/documentation/GetPrivateProfileString.md
@@ -106,6 +106,7 @@ Insights:
 Test Coverage: 
 
 * `Reading_Tests.Given_AnIniFileWithKnownContent_When_TheContentIsAccessed_Then_WeGetTheExpectedValue()`
+* `Reading_Tests.Given_AnIniFileWithDuplicateKeys_When_TheKeyIsRead_Then_WeGetTheFirstOccurrence()`
 * `Casing_Tests.Given_AnEntryWithUpperCaseLetter_When_TheContentIsAccessedWithLowerCase_Then_WeGetTheExpectedValue()`
 * `WhiteSpace_Tests.Given_AnIniFileWrittenWithSpaces_When_TheContentIsWritten_Then_SpacesAreStripped()`
 * `Semicolon_Tests.Given_AnIniFileWithSemicolonAtBeginOfKey_When_TheValueIsRead_Then_WeGetTheDefaultValue()`
@@ -117,10 +118,11 @@ Test Coverage:
 Insights:
 
 * Basically, this functionality works as expected.
-* The key can be accessed case-insensitive
+* The key can be accessed case-insensitive.
+* If the key occurs twice within a section, the first occurrence is returned.
 * The parameter may contain leading and trailing spaces. However, these will be stripped when searching for the key.
 * The parameter may start with a semicolon, but no value will be found, since it will be considered as a comment. The default value will be returned.
-* Tabs, vertical tabs, carraiage returns and newlines are not stripped from the parameter.
+* Tabs, vertical tabs, carriage returns and newlines are not stripped from the parameter.
 * The key parameter may contain single or double quotes. They will not be stripped.
 > If this parameter is **NULL**, all key names in the section specified by the *lpAppName* parameter are copied to the buffer specified by the *lpReturnedString* parameter.
 

--- a/documentation/GetPrivateProfileString.md
+++ b/documentation/GetPrivateProfileString.md
@@ -223,7 +223,7 @@ Test Coverage:
 * `Reading_Tests.Given_ASmallBuffer_When_WeTryToGetTheValue_Then_TheValueIsTruncated()`
 * `Reading_Tests.Given_AZeroBuffer_When_WeTryToGetTheValue_Then_NothingCanBeReturned()`
 * `Limits_Tests.Given_AValueOfLength65534_When_AccessingIt_Then_WeGetTheFullValue()`
-* `Limits_Tests.Given_AValueOfLength65535_When_AccessingIt_Then_WeGetTheFullValueAndAnError()`
+* `Limits_Tests.Given_AValueOfLength65535_When_AccessingIt_Then_WeGetTheFullValue()`
 * `Limits_Tests.Given_AValueOfLength65536_When_AccessingIt_Then_WeGetNothingAndNoError()`
 * `Limits_Tests.Given_AValueOfLength65537_When_AccessingIt_Then_WeGetModuloBehavior()`
 
@@ -232,8 +232,7 @@ Insights:
 * Values are truncated as described, resulting in a return value of *nSize-1*.
 * A zero size buffer returns a zero bytes result (as expected).
 * If the buffer is small and the value is truncated, `GetLastError()` returns `ERROR_MORE_DATA` (234) most of the times (exception see below). See the [list of error messages [MSDN]](https://docs.microsoft.com/en-us/windows/win32/debug/system-error-codes--0-499-).
-* The maximum length of a value that can be read without an error is 65534 bytes.
-* The maximum length of a value that can be read is 65535 bytes in which case `GetLastError()` returns `ERROR_MORE_DATA` (234)  (although there is no more data)
+* The maximum length of a value that can be read without an error is 65535 bytes.
 * Values of *nSize*>=65535 will overflow modulo 65536 and there's no error from `GetLastError()`.
 <a name="lpFileName"></a>
 

--- a/documentation/GetPrivateProfileString.md
+++ b/documentation/GetPrivateProfileString.md
@@ -38,7 +38,7 @@ DWORD GetPrivateProfileString(
 
 <a name="lpAppName"></a>
 
-    [in] lpAppName
+###  `[in] lpAppName`
 
 > The name of the section containing the key name.
 
@@ -97,9 +97,7 @@ Insights:
 
 <a name="lpKeyName"></a>
 
-```
-[in] lpKeyName
-```
+### `[in] lpKeyName`
 
 > The name of the key whose associated string is to be retrieved.
 
@@ -107,6 +105,7 @@ Test Coverage:
 
 * `Reading_Tests.Given_AnIniFileWithKnownContent_When_TheContentIsAccessed_Then_WeGetTheExpectedValue()`
 * `Reading_Tests.Given_AnIniFileWithDuplicateKeys_When_TheKeyIsRead_Then_WeGetTheFirstOccurrence()`
+* `Reading_Tests.Given_AnIniFileWithDuplicateSections_When_TheKeyIsRead_Then_OnlyTheFirstSectionIsConsidered()`
 * `Casing_Tests.Given_AnEntryWithUpperCaseLetter_When_TheContentIsAccessedWithLowerCase_Then_WeGetTheExpectedValue()`
 * `WhiteSpace_Tests.Given_AnIniFileWrittenWithSpaces_When_TheContentIsWritten_Then_SpacesAreStripped()`
 * `Semicolon_Tests.Given_AnIniFileWithSemicolonAtBeginOfKey_When_TheValueIsRead_Then_WeGetTheDefaultValue()`
@@ -120,6 +119,7 @@ Insights:
 * Basically, this functionality works as expected.
 * The key can be accessed case-insensitive.
 * If the key occurs twice within a section, the first occurrence is returned.
+* If the section occurs twice within an INI file, values in the second occurrence are ignored.
 * The parameter may contain leading and trailing spaces. However, these will be stripped when searching for the key.
 * The parameter may start with a semicolon, but no value will be found, since it will be considered as a comment. The default value will be returned.
 * Tabs, vertical tabs, carriage returns and newlines are not stripped from the parameter.
@@ -138,9 +138,8 @@ Insights:
 * Duplicate keys are reported multiple times
 <a name="lpDefault"></a>
 
-```
-[in] lpDefault
-```
+
+### `[in] lpDefault`
 
 > A default string. If the *lpKeyName* key cannot be found in the initialization file, **GetPrivateProfileString** copies the default string to the *lpReturnedString* buffer.
 
@@ -181,9 +180,9 @@ Insights:
 * Leading spaces are not stripped for the default value.
 * "Blank" refers to the space character only, not tab, vertical tab, carriage return and newline.
 <a name="lpReturnedString"></a>
-```
-[out] lpReturnedString
-```
+
+### `[out] lpReturnedString`
+
 For all the C# programmers out there: `[out]` is not identical to `out` parameters as in C#. Obviously this pointer must be valid and point to a buffer where the function writes the data to. I'm not sure whether these API calls are defined in MIDL, but at least the [MIDL definition of [out] [MSDN]](https://docs.microsoft.com/en-us/windows/win32/midl/out-idl#remarks) would match.
 
 > A pointer to the buffer that receives the retrieved string.
@@ -208,9 +207,9 @@ Why could whitespace stripping be done? Probably because some people formatted t
   longerkey= differentvalue
   ```
   <a name="nSize"></a>
-```
-[in] nSize
-```
+
+### `[in] nSize`
+
 > The size of the buffer pointed to by the *lpReturnedString* parameter, in characters.
 
 This is a very interesting parameter, because it's potentially security relevant. If you manage to pass in a value larger than the buffer size, you'll get a buffer overflow with the typical consequences of undefined behavior.
@@ -237,9 +236,9 @@ Insights:
 * The maximum length of a value that can be read is 65535 bytes in which case `GetLastError()` returns `ERROR_MORE_DATA` (234)  (although there is no more data)
 * Values of *nSize*>=65535 will overflow modulo 65536 and there's no error from `GetLastError()`.
 <a name="lpFileName"></a>
-```
-[in] lpFileName
-```
+
+### `[in] lpFileName`
+
 > The name of the initialization file.
 
 Test Coverage:

--- a/source/tests/IniFileFormatTests/IniFileFormatTests.csproj
+++ b/source/tests/IniFileFormatTests/IniFileFormatTests.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>IniFileFormatTests</RootNamespace>
     <AssemblyName>IniFileFormatTests</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>

--- a/source/tests/IniFileFormatTests/Tests/Limits_Tests.cs
+++ b/source/tests/IniFileFormatTests/Tests/Limits_Tests.cs
@@ -63,11 +63,11 @@ namespace IniFileFormatTests.Limits
         [UsedInDocumentation("GetPrivateProfileString.md")]
         [Checks(Parameter.nSize)]
         [TestMethod]
-        public void Given_AValueOfLength65535_When_AccessingIt_Then_WeGetTheFullValueAndAnError()
+        public void Given_AValueOfLength65535_When_AccessingIt_Then_WeGetTheFullValue()
         {
             var result = GetHugeValue(65535, 65535 + 2);
 
-            // Insight: 65535 bytes are returned with an error, although there is no more data
+            // Insight: 65535 bytes are returned without an error
             Assert.AreEqual(0, result.Error);
             Assert.AreEqual((uint)65535, result.Bytes);
         }

--- a/source/tests/IniFileFormatTests/Tests/Reading_Tests.cs
+++ b/source/tests/IniFileFormatTests/Tests/Reading_Tests.cs
@@ -175,13 +175,29 @@ namespace IniFileFormatTests.IntendedUse
         [TestMethod]
         public void Given_AnIniFileWithDuplicateKeys_When_TheKeyIsRead_Then_WeGetTheFirstOccurrence()
         {
-            EnsureASCII($"[{sectionname}]\r\n{keyname}={inivalue}]\r\n{keyname}={inivalue2}");
+            EnsureASCII($"[{sectionname}]\r\n{keyname}={inivalue}\r\n{keyname}={inivalue2}");
             var sb = DefaultStringBuilder();
 
             // Insight: we get the first occurrence
             var bytes = GetIniString_SB_Unicode(sectionname, keyname, defaultvalue, sb, (uint)sb.Capacity, FileName);
             AssertASCIILength(inivalue, bytes);
             AssertSbEqual(inivalue, sb);
+        }
+
+
+        [UsedInDocumentation("GetPrivateProfileString.md")]
+        [Checks(Method.GetPrivateProfileStringW)]
+        [Checks(Parameter.lpKeyName, null)]
+        [TestMethod]
+        public void Given_AnIniFileWithDuplicateSections_When_TheKeyIsRead_Then_OnlyTheFirstSectionIsConsidered()
+        {
+            EnsureASCII($"[{sectionname}]\r\n[{sectionname}]\r\n{keyname}={inivalue}");
+            var sb = DefaultStringBuilder();
+
+            // Insight: we get the default value
+            var bytes = GetIniString_SB_Unicode(sectionname, keyname, defaultvalue, sb, (uint)sb.Capacity, FileName);
+            AssertASCIILength(defaultvalue, bytes);
+            AssertSbEqual(defaultvalue, sb);
         }
 
 

--- a/source/tests/IniFileFormatTests/Tests/Reading_Tests.cs
+++ b/source/tests/IniFileFormatTests/Tests/Reading_Tests.cs
@@ -43,7 +43,7 @@ namespace IniFileFormatTests.IntendedUse
             // Insight: when using the StringBuilder, we get only 1 section name,
             // although there are 2 section names inside.
             // This is probably more a problem of the C# method signature,
-            // but it tells us what can go wrong with with implementations that do not have unit tests :-)
+            // but it tells us what can go wrong with implementations that do not have unit tests :-)
             AssertSbEqual(sectionname, sb);
 
             // Insight: the section names are (probably) delimited by \0. At least the length matches.
@@ -80,7 +80,7 @@ namespace IniFileFormatTests.IntendedUse
         {
             EnsureDefaultContent_UsingAPI();
             var buffer = new char[40];
-            var bytes = GetIniString_ChArr_Unicode(null, keyname, defaultvalue, buffer, (uint)buffer.Length, FileName);
+            GetIniString_ChArr_Unicode(null, keyname, defaultvalue, buffer, (uint)buffer.Length, FileName);
 
             // Insight: The separator character is NUL \0
             Assert.AreEqual('\0', buffer[sectionname.Length]);
@@ -123,7 +123,7 @@ namespace IniFileFormatTests.IntendedUse
         {
             EnsureDefaultContent_UsingAPI();
             var buffer = new char[40];
-            var bytes = GetIniString_ChArr_Unicode(sectionname, null, defaultvalue, buffer, (uint)buffer.Length,
+            GetIniString_ChArr_Unicode(sectionname, null, defaultvalue, buffer, (uint)buffer.Length,
                 FileName);
 
             // Insight: The separator character is NUL \0
@@ -169,6 +169,20 @@ namespace IniFileFormatTests.IntendedUse
             Assert.AreEqual(length * 2 + length2, bytes);
         }
 
+        [UsedInDocumentation("GetPrivateProfileString.md")]
+        [Checks(Method.GetPrivateProfileStringW)]
+        [Checks(Parameter.lpKeyName, null)]
+        [TestMethod]
+        public void Given_AnIniFileWithDuplicateKeys_When_TheKeyIsRead_Then_WeGetTheFirstOccurrence()
+        {
+            EnsureASCII($"[{sectionname}]\r\n{keyname}={inivalue}]\r\n{keyname}={inivalue2}");
+            var sb = DefaultStringBuilder();
+
+            // Insight: we get the first occurrence
+            var bytes = GetIniString_SB_Unicode(sectionname, keyname, defaultvalue, sb, (uint)sb.Capacity, FileName);
+            AssertASCIILength(inivalue, bytes);
+            AssertSbEqual(inivalue, sb);
+        }
 
 
         [UsedInDocumentation("GetPrivateProfileString.md")]


### PR DESCRIPTION
* Upgrade to .NET Framework 4.8
* Add a test for duplicate keys, accessing the value
* Add a test for a the same section occurring twice
* Fix a bug regarding values of length 65535